### PR TITLE
add running scripts to client package

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "",
-    "build": ""
+    "start": "tsc -b -w & NODE_OPTIONS=--preserve-symlinks yarn nodemon ./build/index.js",
+    "build": "tsc -b"
   }
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,13 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["react/experimental"],
-    "noEmit": true,
     "jsx": "preserve",
     "incremental": true,
     "plugins": [
     ],
     "paths": {
-      "@OBSHCHAK-UI/*": [
+      "@app-client/*": [
         "./src/*"
       ]
     }


### PR DESCRIPTION
https://skuratovichaliaksandr.atlassian.net/browse/MOBO-9
https://skuratovichaliaksandr.atlassian.net/browse/MOBO-8

## Description
`packages/client/build` directory is not generated for some reason. The reason is that `noEmit` is `true` in tsconfig.

Probably, `noEmit: true` will be needed in case of using a nextJs setup. But not now.
